### PR TITLE
Pale Reach, Photographer Camp, and more

### DIFF
--- a/DredgeRichPresence.sln
+++ b/DredgeRichPresence.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DredgeRichPresence", "DredgeRichPresence\DredgeRichPresence.csproj", "{E2A04106-3EAB-421A-A3ED-D18D5DBA4420}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E2A04106-3EAB-421A-A3ED-D18D5DBA4420}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2A04106-3EAB-421A-A3ED-D18D5DBA4420}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2A04106-3EAB-421A-A3ED-D18D5DBA4420}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2A04106-3EAB-421A-A3ED-D18D5DBA4420}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C26ED677-A06C-405C-BD6B-5EA6B9C3F4EA}
+	EndGlobalSection
+EndGlobal

--- a/DredgeRichPresence/DredgeRichPresence.cs
+++ b/DredgeRichPresence/DredgeRichPresence.cs
@@ -88,6 +88,7 @@ namespace DredgeRichPresence
 			richPresences.Add("twisted_strand", new RichPresence() { State = "Twisted Strand", Details = "Sailing", Assets = new Assets() { LargeImageKey = "twisted_strand", LargeImageText = "at Twisted Strand", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("devils_spine", new RichPresence() { State = "Devil's Spine", Details = "Sailing", Assets = new Assets() { LargeImageKey = "devils_spine", LargeImageText = "at Devil's Spine", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("stellar_basin", new RichPresence() { State = "Stellar Basin", Details = "Sailing", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "at Stellar Basin", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("pale_reach", new RichPresence() { State = "The Pale Reach", Details = "Sailing", Assets = new Assets() { LargeImageKey = "pale_reach", LargeImageText = "at The Pale Reach", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 
 			/*
 			 * Docks
@@ -125,6 +126,13 @@ namespace DredgeRichPresence
 			richPresences.Add("dock_pontoon_sb", new RichPresence() { State = "Starlight Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Starlight Pontoon", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("dock_old_fort", new RichPresence() { State = "Old Fortress", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Old Fortress", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("dock_research_pontoon", new RichPresence() { State = "Research Outpost", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Research Outpost", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+
+			// Pale Reach
+			richPresences.Add("dock_pontoon_tpr", new RichPresence() { State = "Bleak Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "pale_reach", LargeImageText = "Docked at the Bleak Pontoon", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_tpr_middle", new RichPresence() { State = "Pale Reach Central Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "pale_reach", LargeImageText = "Docked at the Pale Reach's Central Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_tpr_west", new RichPresence() { State = "Western Bearing", Details = "Docked", Assets = new Assets() { LargeImageKey = "pale_reach", LargeImageText = "Docked at the Pale Reach's Western Bearing", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_tpr_south", new RichPresence() { State = "Southern Locus", Details = "Docked", Assets = new Assets() { LargeImageKey = "pale_reach", LargeImageText = "Docked at the Pale Reach's Southern Locus", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_tpr_east", new RichPresence() { State = "Eastern Terminus", Details = "Docked", Assets = new Assets() { LargeImageKey = "pale_reach", LargeImageText = "Docked at the Pale Reach's Eastern Terminus", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 		}
 
 		/// <summary>

--- a/DredgeRichPresence/DredgeRichPresence.cs
+++ b/DredgeRichPresence/DredgeRichPresence.cs
@@ -86,7 +86,7 @@ namespace DredgeRichPresence
 			richPresences.Add("gale_cliffs", new RichPresence() { State = "Gale Cliffs", Details = "Sailing", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "at Gale Cliffs", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("twisted_strand", new RichPresence() { State = "Twisted Strand", Details = "Sailing", Assets = new Assets() { LargeImageKey = "twisted_strand", LargeImageText = "at Twisted Strand", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("devils_spine", new RichPresence() { State = "Devil's Spine", Details = "Sailing", Assets = new Assets() { LargeImageKey = "devils_spine", LargeImageText = "at Devil's Spine", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
-			richPresences.Add("stellar_bassin", new RichPresence() { State = "Stellar Bassin", Details = "Sailing", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "at Stellar Bassin", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("stellar_basin", new RichPresence() { State = "Stellar Basin", Details = "Sailing", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "at Stellar Basin", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 
 			/*
 			 * Docks
@@ -116,8 +116,8 @@ namespace DredgeRichPresence
 			richPresences.Add("dock_pontoon_ts", new RichPresence() { State = "Rickety Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "twisted_strand", LargeImageText = "Docked at the Rickety Pontoon", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("dock_soldier_camp", new RichPresence() { State = "Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "twisted_strand", LargeImageText = "Docked at the Soldier Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 
-			// Stellar Bassin
-			richPresences.Add("dock_old_mayor_sb", new RichPresence() { State = "Stellar Bassin Old Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Astral Bassin Old Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			// Stellar Basin
+			richPresences.Add("dock_old_mayor_sb", new RichPresence() { State = "Stellar Basin Old Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Stellar Basin Old Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("dock_pontoon_sb", new RichPresence() { State = "Starlight Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Starlight Pontoon", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("dock_old_fort", new RichPresence() { State = "Old Fortress", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Old Fortress", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("dock_research_pontoon", new RichPresence() { State = "Research Outpost", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Research Outpost", SmallImageKey = "main_menu" }, Timestamps = timeStarted });

--- a/DredgeRichPresence/DredgeRichPresence.cs
+++ b/DredgeRichPresence/DredgeRichPresence.cs
@@ -9,13 +9,13 @@ namespace DredgeRichPresence
 	public class DredgeRichPresence : MonoBehaviour
 	{
 
-        public static DredgeRichPresence Instance { get; private set; }
+		public static DredgeRichPresence Instance { get; private set; }
 
-        [NonSerialized]
+		[NonSerialized]
 		private static DiscordRpcClient client;
 
-        [NonSerialized]
-        public Dictionary<string, RichPresence> richPresences = [];
+		[NonSerialized]
+		public Dictionary<string, RichPresence> richPresences = [];
 
 		[NonSerialized]
 		private static Timestamps timeStarted;
@@ -31,7 +31,7 @@ namespace DredgeRichPresence
 		private bool DayTime;
 
 		public void Awake()
-        {
+		{
 			Instance = this;
 
 			GameManager.Instance.OnGameStarted += GameStarted;
@@ -42,32 +42,32 @@ namespace DredgeRichPresence
 			client = new DiscordRpcClient("1232072940418371614");
 			WinchCore.Log.Info("Client created.");
 
-            // Calling the init function
-            client.Initialize();
-            WinchCore.Log.Info("Client initialized.");
+			// Calling the init function
+			client.Initialize();
+			WinchCore.Log.Info("Client initialized.");
 
-            client.OnReady += (sender, msg) =>
-            {
-                //Create some events so we know things are happening
-                Console.WriteLine("Connected to discord with user {0}", msg.User.Username);
-            };
+			client.OnReady += (sender, msg) =>
+			{
+				//Create some events so we know things are happening
+				Console.WriteLine("Connected to discord with user {0}", msg.User.Username);
+			};
 
-            // Saving the timestamp when the game started
-            timeStarted = Timestamps.Now;
+			// Saving the timestamp when the game started
+			timeStarted = Timestamps.Now;
 
 			// Initialize presences
 			InitializePresences();
-            WinchCore.Log.Info("Presences initialized.");
+			WinchCore.Log.Info("Presences initialized.");
 
-            // Setting the presence for the main menu
-            client.SetPresence(richPresences["main_menu"]);
+			// Setting the presence for the main menu
+			client.SetPresence(richPresences["main_menu"]);
 
 			OnZoneChanged += ZoneChangedHandler;
 
-            WinchCore.Log.Debug($"{nameof(DredgeRichPresence)} has loaded!");
-        }
+			WinchCore.Log.Debug($"{nameof(DredgeRichPresence)} has loaded!");
+		}
 
-        public void Update()
+		public void Update()
 		{
 			if (Instance == null) return;
 			if (!InGame) return;
@@ -75,53 +75,53 @@ namespace DredgeRichPresence
 			ParseLocation();
 		}
 
-        /// <summary>
-        /// This function initialize the presences and add them to the presence dictionnary
-        /// </summary>
-        private void InitializePresences()
+		/// <summary>
+		/// This function initialize the presences and add them to the presence dictionnary
+		/// </summary>
+		private void InitializePresences()
 		{
-			richPresences.Add("main_menu", new RichPresence() { Details = "Main Menu", Assets = new Assets() { LargeImageKey = "main_menu", LargeImageText = "Main Menu" , SmallImageKey = "main_menu" } , Timestamps = timeStarted});
+			richPresences.Add("main_menu", new RichPresence() { Details = "Main Menu", Assets = new Assets() { LargeImageKey = "main_menu", LargeImageText = "Main Menu", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("the_marrows", new RichPresence() { State = "The Marrows", Details = "Sailing", Assets = new Assets() { LargeImageKey = "the_marrows", LargeImageText = "at The Marrows", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("open_ocean", new RichPresence() { State = "The ocean", Details = "Sailing", Assets = new Assets() { LargeImageKey = "open_ocean", LargeImageText = "In the ocean", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
-            richPresences.Add("gale_cliffs", new RichPresence() { State = "Gale Cliffs", Details = "Sailing", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "at Gale Cliffs", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
-            richPresences.Add("twisted_strand", new RichPresence() { State = "Twisted Strand", Details = "Sailing", Assets = new Assets() { LargeImageKey = "twisted_strand", LargeImageText = "at Twisted Strand", SmallImageKey = "main_menu" } , Timestamps = timeStarted });
-            richPresences.Add("devils_spine", new RichPresence() { State = "Devil's Spine", Details = "Sailing", Assets = new Assets() { LargeImageKey = "devils_spine", LargeImageText = "at Devil's Spine", SmallImageKey = "main_menu" } , Timestamps = timeStarted });
-            richPresences.Add("stellar_bassin", new RichPresence() { State = "Stellar Bassin", Details = "Sailing", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "at Stellar Bassin", SmallImageKey = "main_menu" } , Timestamps = timeStarted });
-            
+			richPresences.Add("gale_cliffs", new RichPresence() { State = "Gale Cliffs", Details = "Sailing", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "at Gale Cliffs", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("twisted_strand", new RichPresence() { State = "Twisted Strand", Details = "Sailing", Assets = new Assets() { LargeImageKey = "twisted_strand", LargeImageText = "at Twisted Strand", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("devils_spine", new RichPresence() { State = "Devil's Spine", Details = "Sailing", Assets = new Assets() { LargeImageKey = "devils_spine", LargeImageText = "at Devil's Spine", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("stellar_bassin", new RichPresence() { State = "Stellar Bassin", Details = "Sailing", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "at Stellar Bassin", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+
 			/*
 			 * Docks
 			 */
 
 			// The marrows
-			richPresences.Add("dock_greater_marrow", new RichPresence() { State = "Greater Marrow", Details = "Docked", Assets = new Assets() { LargeImageKey = "the_marrows", LargeImageText = "Docked at the Greater Marrow", SmallImageKey = "main_menu" } , Timestamps = timeStarted });
-			richPresences.Add("dock_little_marrow", new RichPresence() { State = "Little Marrow", Details = "Docked", Assets = new Assets() { LargeImageKey = "the_marrows", LargeImageText = "Docked at the Little Marrow", SmallImageKey = "main_menu" } , Timestamps = timeStarted });
-			richPresences.Add("dock_outcast_isle", new RichPresence() { State = "Blackstone Isle", Details = "Docked", Assets = new Assets() { LargeImageKey = "outcast_isle", LargeImageText = "Docked at the Blackstone isle", SmallImageKey = "main_menu" } , Timestamps = timeStarted });
-			richPresences.Add("dock_steel_point", new RichPresence() { State = "Steel Point", Details = "Docked", Assets = new Assets() { LargeImageKey = "the_marrows", LargeImageText = "Docked at Steel Point", SmallImageKey = "main_menu" } , Timestamps = timeStarted });
-            //richPresences.Add("dock_greater_marrow", new RichPresence() { State = "Greater Marrow", Details = "Docked", Assets = new Assets() { LargeImageKey = "the_marrows", LargeImageText = "Docked at the Greater Marrow" } , Timestamps = timeStarted });
+			richPresences.Add("dock_greater_marrow", new RichPresence() { State = "Greater Marrow", Details = "Docked", Assets = new Assets() { LargeImageKey = "the_marrows", LargeImageText = "Docked at the Greater Marrow", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_little_marrow", new RichPresence() { State = "Little Marrow", Details = "Docked", Assets = new Assets() { LargeImageKey = "the_marrows", LargeImageText = "Docked at the Little Marrow", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_outcast_isle", new RichPresence() { State = "Blackstone Isle", Details = "Docked", Assets = new Assets() { LargeImageKey = "outcast_isle", LargeImageText = "Docked at the Blackstone isle", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_steel_point", new RichPresence() { State = "Steel Point", Details = "Docked", Assets = new Assets() { LargeImageKey = "the_marrows", LargeImageText = "Docked at Steel Point", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			//richPresences.Add("dock_greater_marrow", new RichPresence() { State = "Greater Marrow", Details = "Docked", Assets = new Assets() { LargeImageKey = "the_marrows", LargeImageText = "Docked at the Greater Marrow" } , Timestamps = timeStarted });
 
-            // Gale Cliffs
-            richPresences.Add("dock_old_mayor_gc", new RichPresence() { State = "Gale Cliffs' Old Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "Docked at the Gale Cliffs' Old Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
-            richPresences.Add("dock_pontoon_gc", new RichPresence() { State = "Dusty Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "Docked at the Gale Cliffs' Pontoon", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
-            richPresences.Add("dock_gale_cliffs", new RichPresence() { State = "Ruins", Details = "Docked", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "Docked at the Gale Cliffs' Ruins", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
-            richPresences.Add("dock_ingfell", new RichPresence() { State = "Ingfell", Details = "Docked", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "Docked at Ingfell", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			// Gale Cliffs
+			richPresences.Add("dock_old_mayor_gc", new RichPresence() { State = "Gale Cliffs' Old Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "Docked at the Gale Cliffs' Old Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_pontoon_gc", new RichPresence() { State = "Dusty Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "Docked at the Gale Cliffs' Pontoon", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_gale_cliffs", new RichPresence() { State = "Ruins", Details = "Docked", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "Docked at the Gale Cliffs' Ruins", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_ingfell", new RichPresence() { State = "Ingfell", Details = "Docked", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "Docked at Ingfell", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 
-            // Devils spine
-            richPresences.Add("dock_ds_temple", new RichPresence() { State = "Ancient Temple", Details = "Docked", Assets = new Assets() { LargeImageKey = "devils_spine", LargeImageText = "Docked at the Ancient Temple", SmallImageKey = "main_menu" } , Timestamps = timeStarted });
-			richPresences.Add("dock_pontoon_ds", new RichPresence() { State = "Charred Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "devils_spine", LargeImageText = "Docked at the Charred Pontoon", SmallImageKey = "main_menu" } , Timestamps = timeStarted });
-			richPresences.Add("dock_ancient_ruins", new RichPresence() { State = "Ancient Ruins", Details = "Docked", Assets = new Assets() { LargeImageKey = "devils_spine", LargeImageText = "Docked at the Ancient Ruins", SmallImageKey = "main_menu" } , Timestamps = timeStarted });
-			richPresences.Add("dock_old_mayor_ds", new RichPresence() { State = "Devil's Spine Old Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "devils_spine", LargeImageText = "Docked at the Devil's Spine's Old Camp", SmallImageKey = "main_menu" } , Timestamps = timeStarted });
+			// Devils spine
+			richPresences.Add("dock_ds_temple", new RichPresence() { State = "Ancient Temple", Details = "Docked", Assets = new Assets() { LargeImageKey = "devils_spine", LargeImageText = "Docked at the Ancient Temple", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_pontoon_ds", new RichPresence() { State = "Charred Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "devils_spine", LargeImageText = "Docked at the Charred Pontoon", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_ancient_ruins", new RichPresence() { State = "Ancient Ruins", Details = "Docked", Assets = new Assets() { LargeImageKey = "devils_spine", LargeImageText = "Docked at the Ancient Ruins", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_old_mayor_ds", new RichPresence() { State = "Devil's Spine Old Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "devils_spine", LargeImageText = "Docked at the Devil's Spine's Old Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 
-            // Twisted strand
-            richPresences.Add("dock_old_mayor_ts", new RichPresence() { State = "Twisted Strand Old Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "twisted_strand", LargeImageText = "Docked at the Twisted Strand's Old Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
-            richPresences.Add("dock_pontoon_ts", new RichPresence() { State = "Rickety Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "twisted_strand", LargeImageText = "Docked at the Rickety Pontoon", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
-            richPresences.Add("dock_soldier_camp", new RichPresence() { State = "Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "twisted_strand", LargeImageText = "Docked at the Soldier Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			// Twisted strand
+			richPresences.Add("dock_old_mayor_ts", new RichPresence() { State = "Twisted Strand Old Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "twisted_strand", LargeImageText = "Docked at the Twisted Strand's Old Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_pontoon_ts", new RichPresence() { State = "Rickety Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "twisted_strand", LargeImageText = "Docked at the Rickety Pontoon", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_soldier_camp", new RichPresence() { State = "Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "twisted_strand", LargeImageText = "Docked at the Soldier Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 
-            // Stellar Bassin
-            richPresences.Add("dock_old_mayor_sb", new RichPresence() { State = "Stellar Bassin Old Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Astral Bassin Old Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
-            richPresences.Add("dock_pontoon_sb", new RichPresence() { State = "Starlight Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Starlight Pontoon", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
-            richPresences.Add("dock_old_fort", new RichPresence() { State = "Old Fortress", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Old Fortress", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
-            richPresences.Add("dock_research_pontoon", new RichPresence() { State = "Research Outpost", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Research Outpost", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
-        }
+			// Stellar Bassin
+			richPresences.Add("dock_old_mayor_sb", new RichPresence() { State = "Stellar Bassin Old Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Astral Bassin Old Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_pontoon_sb", new RichPresence() { State = "Starlight Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Starlight Pontoon", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_old_fort", new RichPresence() { State = "Old Fortress", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Old Fortress", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+			richPresences.Add("dock_research_pontoon", new RichPresence() { State = "Research Outpost", Details = "Docked", Assets = new Assets() { LargeImageKey = "bassin_astral", LargeImageText = "Docked at the Research Outpost", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+		}
 
 		/// <summary>
 		/// This function parse the location and trigger the event
@@ -132,7 +132,7 @@ namespace DredgeRichPresence
 			// If the zone is different, change it and update
 			CurrentZone = GameManager.Instance.Player.PlayerZoneDetector.GetCurrentZone();
 			OnZoneChanged?.Invoke(CurrentZone); // Call the event
-        }
+		}
 
 		/// <summary>
 		/// This function handles the OnGameStarted event
@@ -142,16 +142,16 @@ namespace DredgeRichPresence
 			CurrentZone = GameManager.Instance.Player.PlayerZoneDetector.GetCurrentZone(); // Setting the current zone where the player is
 			InGame = true; // saving the state of the game
 
-            GameEvents.Instance.OnPlayerDockedToggled += PlayerDockedEvent; // Adding my handler to the original event
+			GameEvents.Instance.OnPlayerDockedToggled += PlayerDockedEvent; // Adding my handler to the original event
 
 			PlayerDockedEvent(GameManager.Instance.Player.CurrentDock); // Calling the function to set the presence
-        }
+		}
 
-        /// <summary>
-        /// This function handles the OnZoneChanged event
-        /// </summary>
-        /// <param name="zone">The current zone</param>
-        private void ZoneChangedHandler(ZoneEnum zone)
+		/// <summary>
+		/// This function handles the OnZoneChanged event
+		/// </summary>
+		/// <param name="zone">The current zone</param>
+		private void ZoneChangedHandler(ZoneEnum zone)
 		{
 			//WinchCore.Log.Debug("ZoneChangedHandler()");
 			SetRichPresence(zone.ToString().ToLower()); // Parsing the zone name (THE_MARROWS -> the_marrows)
@@ -163,10 +163,10 @@ namespace DredgeRichPresence
 		/// <param name="dock">The dock the player is at</param>
 		private void PlayerDockedEvent(Dock dock)
 		{
-            //WinchCore.Log.Debug("PlayerDockedEvent()");
-            if (dock == null) // If the player isn't docked anymore
-            {
-                ZoneChangedHandler(GameManager.Instance.Player.PlayerZoneDetector.GetCurrentZone());
+			//WinchCore.Log.Debug("PlayerDockedEvent()");
+			if (dock == null) // If the player isn't docked anymore
+			{
+				ZoneChangedHandler(GameManager.Instance.Player.PlayerZoneDetector.GetCurrentZone());
 				return;
 			}
 			string name = dock.dockData.id.Replace(".", "_").Replace("-", "_"); // parsing the dock's name (dock.greater-marrow -> dock_greater_marrow)
@@ -181,5 +181,5 @@ namespace DredgeRichPresence
 		{
 			client.SetPresence(richPresences[id]); // Set the presence
 		}
-    }
+	}
 }

--- a/DredgeRichPresence/DredgeRichPresence.cs
+++ b/DredgeRichPresence/DredgeRichPresence.cs
@@ -35,6 +35,7 @@ namespace DredgeRichPresence
 			Instance = this;
 
 			GameManager.Instance.OnGameStarted += GameStarted;
+			GameManager.Instance.OnGameEnded += GameEnded;
 
 			InGame = false;
 
@@ -60,7 +61,7 @@ namespace DredgeRichPresence
 			WinchCore.Log.Info("Presences initialized.");
 
 			// Setting the presence for the main menu
-			client.SetPresence(richPresences["main_menu"]);
+			SetRichPresence("main_menu");
 
 			OnZoneChanged += ZoneChangedHandler;
 
@@ -145,6 +146,17 @@ namespace DredgeRichPresence
 			GameEvents.Instance.OnPlayerDockedToggled += PlayerDockedEvent; // Adding my handler to the original event
 
 			PlayerDockedEvent(GameManager.Instance.Player.CurrentDock); // Calling the function to set the presence
+		}
+
+		/// <summary>
+		/// This function handles the OnGameEnded event
+		/// </summary>
+		private void GameEnded()
+		{
+			InGame = false;
+
+			// Setting the presence for the main menu
+			SetRichPresence("main_menu");
 		}
 
 		/// <summary>

--- a/DredgeRichPresence/DredgeRichPresence.cs
+++ b/DredgeRichPresence/DredgeRichPresence.cs
@@ -182,7 +182,7 @@ namespace DredgeRichPresence
 				return;
 			}
 			string name = dock.dockData.id.Replace(".", "_").Replace("-", "_"); // parsing the dock's name (dock.greater-marrow -> dock_greater_marrow)
-			client.SetPresence(richPresences[name]); // Setting the presence from the richPresences list
+			SetRichPresence(name); // Setting the presence from the richPresences list
 		}
 
 		/// <summary>
@@ -191,7 +191,14 @@ namespace DredgeRichPresence
 		/// <param name="id">the id of the presence</param>
 		private void SetRichPresence(string id)
 		{
-			client.SetPresence(richPresences[id]); // Set the presence
+			if (richPresences.ContainsKey(id))
+			{
+				client.SetPresence(richPresences[id]); // Set the presence
+			}
+			else
+			{
+				WinchCore.Log.Error($"Tried to set presence but id \"{id}\" does not exist.");
+			}
 		}
 	}
 }

--- a/DredgeRichPresence/DredgeRichPresence.cs
+++ b/DredgeRichPresence/DredgeRichPresence.cs
@@ -100,6 +100,9 @@ namespace DredgeRichPresence
 			richPresences.Add("dock_steel_point", new RichPresence() { State = "Steel Point", Details = "Docked", Assets = new Assets() { LargeImageKey = "the_marrows", LargeImageText = "Docked at Steel Point", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			//richPresences.Add("dock_greater_marrow", new RichPresence() { State = "Greater Marrow", Details = "Docked", Assets = new Assets() { LargeImageKey = "the_marrows", LargeImageText = "Docked at the Greater Marrow" } , Timestamps = timeStarted });
 
+			// Open Ocean
+			richPresences.Add("dock_photographer_camp", new RichPresence() { State = "Expedition Site", Details = "Docked", Assets = new Assets() { LargeImageKey = "open_ocean", LargeImageText = "Docked at the Expedition Site", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
+
 			// Gale Cliffs
 			richPresences.Add("dock_old_mayor_gc", new RichPresence() { State = "Gale Cliffs' Old Camp", Details = "Docked", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "Docked at the Gale Cliffs' Old Camp", SmallImageKey = "main_menu" }, Timestamps = timeStarted });
 			richPresences.Add("dock_pontoon_gc", new RichPresence() { State = "Dusty Pontoon", Details = "Docked", Assets = new Assets() { LargeImageKey = "gale_cliffs", LargeImageText = "Docked at the Gale Cliffs' Pontoon", SmallImageKey = "main_menu" }, Timestamps = timeStarted });

--- a/DredgeRichPresence/DredgeRichPresence.csproj
+++ b/DredgeRichPresence/DredgeRichPresence.csproj
@@ -45,23 +45,4 @@
 	  </Reference>
 	</ItemGroup>
 
-	<ItemGroup>
-		<None Update="Assets\Items\Engines\moredredge.bigengine.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<None Update="Assets\Localization\en.json">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<None Update="Assets\Textures\moredredge.bigengine.png">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<None Update="Assets\Localization\fr.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="Assets\Items\Books\" />
-	</ItemGroup>
-
 </Project>

--- a/DredgeRichPresence/DredgeRichPresence.csproj
+++ b/DredgeRichPresence/DredgeRichPresence.csproj
@@ -26,8 +26,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DredgeGameLibs" Version="1.3.0" />
-		<PackageReference Include="Winch" Version="0.2.3" />
+		<PackageReference Include="DredgeGameLibs" Version="1.4.2" />
+		<PackageReference Include="Winch" Version="0.3.1" />
 		<PackageReference Include="DiscordRichPresence" Version="1.2.1.24">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</PackageReference>

--- a/DredgeRichPresence/Loader.cs
+++ b/DredgeRichPresence/Loader.cs
@@ -1,5 +1,4 @@
-﻿using DredgeRichPresence.Libs;
-using HarmonyLib;
+﻿using HarmonyLib;
 using UnityEngine;
 
 namespace DredgeRichPresence
@@ -13,9 +12,8 @@ namespace DredgeRichPresence
 		{
 			var gameObject = new GameObject(nameof(DredgeRichPresence));
 			gameObject.AddComponent<DredgeRichPresence>();
-			gameObject.AddComponent<CustomSceneManager>();
 			GameObject.DontDestroyOnLoad(gameObject);
-            new Harmony(nameof(DredgeRichPresence)).PatchAll();
-        }
+			new Harmony(nameof(DredgeRichPresence)).PatchAll();
+		}
 	}
 }

--- a/DredgeRichPresence/mod_meta.json
+++ b/DredgeRichPresence/mod_meta.json
@@ -1,8 +1,8 @@
 {
 	"Name": "DredgeRichPresence",
 	"ModGUID": "DaSea.DredgeRichPresence",
-	"Version": "0.0.1",
+	"Version": "1.1.0",
 	"ModAssembly": "DredgeRichPresence.dll",
-	"MinWinchVersion": "0.2.3",
+	"MinWinchVersion": "0.3.1",
 	"Entrypoint": "DredgeRichPresence.Loader/Initialize"
 }


### PR DESCRIPTION
- Added support for The Pale Reach and all its docks. Still needs a large image though. I suggest this one.
![PaleReach](https://github.com/SeaKestrel/DredgeRichPresence/assets/34462599/5d116001-784f-4a34-88a8-c1660e62a931)
- Added missing presence for the Photographer's Expedition Site dock
- Fixed stellar basin not showing because the id was bassin.
- Now sets presence when going back to main menu
- Error prevention when setting presence (check if id has a presence, if not then ignore it and log)
- Formatted and cleanup (which will make this pr harder to read because you'll probably have to read by commit)